### PR TITLE
styles.css: fix webkit blur

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,6 +155,7 @@ header::before {
     text-shadow: none;
     color: #333;
     backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     background: rgba(255, 255, 255, 0.15);
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 0;


### PR DESCRIPTION
This PR adds `-webkit-backdrop-filter` to the CSS so the blur is rendered correctly on Safari. CC @mazabou.